### PR TITLE
oauth2: make enforce pkce configurable.

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -365,6 +365,9 @@ oauth2:
       # Sets the BCrypt cost. Minimum value is 4 and default value is 10. The higher the value, the more CPU time is being
       # used to generate hashes.
       cost: 10
+  pkce:
+    # Set this to true if you want PKCE to be enforced for all clients.
+    enforced: false
 
 # The secrets section configures secrets used for encryption and signing of several systems. All secrets can be rotated,
 # for more information on this topic navigate to:

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -58,6 +58,7 @@ type Provider interface {
 	LogoutRedirectURL() *url.URL
 	LoginURL() *url.URL
 	LogoutURL() *url.URL
+	PKCEEnforced() bool
 }
 
 func MustValidate(l logrus.FieldLogger, p Provider) {

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -66,6 +66,7 @@ const (
 	ViperKeyAllowTLSTerminationFrom        = "serve.tls.allow_termination_from"
 	ViperKeyAccessTokenStrategy            = "strategies.access_token"
 	ViperKeySubjectIdentifierAlgorithmSalt = "oidc.subject_identifiers.pairwise.salt"
+	ViperKeyPKCEEnforced                   = "oauth2.pkce.enforced"
 )
 
 func init() {
@@ -407,4 +408,8 @@ func (v *ViperProvider) OIDCDiscoveryUserinfoEndpoint() string {
 
 func (v *ViperProvider) ShareOAuth2Debug() bool {
 	return viperx.GetBool(v.l, "oauth2.expose_internal_errors", false, "OAUTH2_SHARE_ERROR_DEBUG")
+}
+
+func (v *ViperProvider) PKCEEnforced() bool {
+	return viperx.GetBool(v.l, ViperKeyPKCEEnforced, false, "OAUTH2_PKCE_ENFORCED")
 }

--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -230,7 +230,7 @@ func (m *RegistryBase) oAuth2Config() *compose.Config {
 		HashCost:                       m.c.BCryptCost(),
 		ScopeStrategy:                  m.ScopeStrategy(),
 		SendDebugMessagesToClients:     m.c.ShareOAuth2Debug(),
-		EnforcePKCE:                    true,
+		EnforcePKCE:                    m.c.PKCEEnforced(),
 		EnablePKCEPlainChallengeMethod: false,
 		TokenURL:                       urlx.AppendPaths(m.c.PublicURL(), oauth2.TokenPath).String(),
 		RedirectSecureChecker:          x.IsRedirectURISecure(m.c),


### PR DESCRIPTION
You can now configure hydra to enforce PKCE.
See the yaml configuration file.
#1577